### PR TITLE
New RIP for Reserving Tx Type

### DIFF
--- a/RIPS/rip-7879.md
+++ b/RIPS/rip-7879.md
@@ -1,0 +1,45 @@
+---
+rip: 7879
+title: Reserve Transaction Type Number Range for Rollups
+description: Reserves transaction type number range for use by rollups and L1
+author: Nikola Mratinic (@mralj), Diptanshu Kakwani (@dipkakwani)
+discussions-to: https://ethereum-magicians.org/t/rip<TBD>
+status: Draft
+type: Standards Track
+category: Core
+created: 2025-04-25
+---
+
+## Abstract
+
+This RIP reserves transaction type number range to ensure that there are no conflicts between transaction types used by the L1 and various rollups (L2s and L3+).
+
+## Motivation
+
+As L2s begin to deploy RIPs, it is necessary to reserve a transaction type range for use by the RIP process so as to ensure there are no conflicts between transaction types used by RIPs and EIPs.
+
+## Specification
+
+Transaction types are 8-bit unsigned integers with possible values ranging from `0` to `0x7f` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
+
+This RIP reserves the following transaction type ranges:
+
+- `0x00` to `0x3f` (0-63): Reserved for L1
+- `0x40` to `0x5f` (64-95): Reserved for L2 rollups
+- `0x60` to `0x7f` (96-127): Reserved for future usage (e.g. L3+ rollups)
+
+## Rationale
+
+By reserving a range for RIPs, it allows the RIP process to maintain its own set of transactions types that are not necessarily used in the L1. It also ensures that the already existing reserved bits are proportionally divided among the L1, L2s and L3s+.
+
+## Backwards Compatibility
+
+No backward compatibility issues found.
+
+## Security Considerations
+
+Nil.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
RIP for ensuring that rollups use a dedicated range for the transaction types. Similar to https://eips.ethereum.org/EIPS/eip-7587 which reserves precompile address range for rollups.